### PR TITLE
kernel plugins: lfa: add missing #ifdef directives

### DIFF
--- a/plugins/lfa/ps.c
+++ b/plugins/lfa/ps.c
@@ -77,8 +77,10 @@ static struct pft_port_entry *pft_pe_create_gfp(gfp_t flags,
 static struct pft_port_entry *pft_pe_create_ni(port_id_t port_id)
 { return pft_pe_create_gfp(GFP_ATOMIC, port_id); }
 
+#ifdef CONFIG_RINA_ASSERTIONS
 static bool pft_pe_is_ok(struct pft_port_entry *pe)
 { return pe ? true : false;  }
+#endif
 
 static void pft_pe_destroy(struct pft_port_entry *pe)
 {
@@ -119,8 +121,10 @@ static struct pft_entry *pfte_create_ni(address_t destination,
 					qos_id_t qos_id)
 { return pfte_create_gfp(GFP_ATOMIC, destination, qos_id); }
 
+#ifdef CONFIG_RINA_ASSERTIONS
 static bool pfte_is_ok(struct pft_entry *entry)
 { return entry ? true : false; }
+#endif
 
 static void pfte_destroy(struct pft_entry *entry)
 {


### PR DESCRIPTION
We must check for CONFIG_RINA_ASSERTION being defined before
defining checker functions.
